### PR TITLE
Drop inactive tasklist syntax from default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,7 @@ How did you make sure this worked? How can a reviewer verify this?
 
 # To-do list
 
-```[tasklist]
 - [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
 - [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
 - [ ] Review the PR yourself and call out any questions or issues you have
-```
+


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

The `[tasklist]` syntax in the to-do list section of the template no longer works.

This PR replaces the tasklist with standard checklist syntax.

# Testing

How did you make sure this worked? How can a reviewer verify this?

View source on this post ;)

# To-do list

- [x] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
